### PR TITLE
Implement various improvements

### DIFF
--- a/visibilitytracker/src/main/java/io/hevinxx/visibilitytracker/VisibilityTracker.kt
+++ b/visibilitytracker/src/main/java/io/hevinxx/visibilitytracker/VisibilityTracker.kt
@@ -88,21 +88,26 @@ fun Modifier.onVisibilityChanged(
     var isStarted by remember {
         mutableStateOf(false)
     }
-    val visibleRatio by remember {
-        derivedStateOf {
-            if (treatOnStopAsInvisible && !isStarted) {
-                0f
-            } else if (contentBounds.isEmpty) {
-                0f
-            } else {
-                (givenArea.width * givenArea.height) / (contentBounds.width * contentBounds.height)
-            }
-        }
-    }
+    var visibleRatio by remember { mutableFloatStateOf(0f) }
 
     var lastVisibleRatio by remember { mutableFloatStateOf(0f) }
 
-    LaunchedEffect(key1 = visibleRatio) {
+    LaunchedEffect(
+        treatOnStopAsInvisible,
+        isStarted,
+        contentBounds,
+        givenArea
+    ) {
+        visibleRatio = if (treatOnStopAsInvisible && !isStarted) {
+            0f
+        } else if (contentBounds.isEmpty) {
+            0f
+        } else {
+            (givenArea.width * givenArea.height) / (contentBounds.width * contentBounds.height)
+        }
+    }
+
+    LaunchedEffect(visibleRatio) {
         val wasAbove = lastVisibleRatio >= threshold
         val isAbove = visibleRatio >= threshold
         if (wasAbove != isAbove) {


### PR DESCRIPTION
# Description
Thank you for implementing such a useful library. I've been using it very effectively. However, while using it, I thought of a few improvements that could be made, so I proceeded with some work. The details of the work are as follows. (As there was no specific PR template, I've written this in a general style.)


# Detailed explanation of changes
## 1. Chaining as a Modifier function : https://github.com/hevinxx/visibility-tracker/commit/a5464d9b60a683e8da39a329f63612c495f7aa47

In the existing implementation, the View which exposure you wanted to check always had to be wrapped in a VisibilityTracker. This created additional line breaks and could harm readability, especially for deep UI hierarchies. Therefore, I added a function that can be called directly from the Modifier without creating additional line breaks.

Trade-off: When used as a Modifier function, the area judged for exposure can change depending on the chaining order. 
(For example, when padding is applied before/after the onVisibilityChanged function)

## 2. Change in visibleRatio implementation : https://github.com/hevinxx/visibility-tracker/commit/e2e665bd79e1c739792d383b73fcb8700232408f

I changed visibleRatio from derivedStateOf to LaunchedEffect-based implementation.
According to [the official documentation](https://developer.android.com/develop/ui/compose/side-effects?hl=ko#derivedstateof), derivedStateOf is suggested for use in situations where the number of recompositions and actual data state changes are mismatched. For example, it can be used for states that converge to a specific state, such as Boolean values or roundToInt.

However, visibleRatio is different. Except for some special situations, visibleRatio is composed of a combination of givenArea and contentBounds values, so its value changes every time. (Checking the exposure ratio of UI essentially means it's used in scrollable UI where exposed/unexposed states coexist. And in scrollable UI, givenArea and contentBounds change with each scroll, which means the visibleRatio value changes every time as well.)

Therefore, I thought there was no advantage to using derivedStateOf and modified it to an implementation based on LaunchedEffect.